### PR TITLE
Counting jobs in progress for Resque

### DIFF
--- a/lib/hirefire/macro/resque.rb
+++ b/lib/hirefire/macro/resque.rb
@@ -18,7 +18,10 @@ module HireFire
       def queue(*queues)
         return ::Resque.info[:pending].to_i if queues.empty?
         queues = queues.flatten.map(&:to_s)
-        queues.inject(0) { |memo, queue| memo += ::Resque.size(queue); memo }
+        in_queues = queues.inject(0) { |memo, queue| memo += ::Resque.size(queue); memo }
+        in_progress = ::Resque::Worker.all.select{|worker| queues.include?(worker.job['queue']) }.count
+        
+        in_queues + in_progress
       end
     end
   end


### PR DESCRIPTION
This Macro is only counting the jobs in the queues and skips counting those that are being actively worked on. We need to look at the workers to see which jobs are active, otherwise we could have
the case where we spin up n workers for n jobs, each worker takes a job, there are 0 jobs left on the queue, and all the workers are spun down even though they are in the process of working.
