### PR TITLE
DynoList changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,26 @@
+PATH
+  remote: .
+  specs:
+    hirefire-resource (0.2.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    rack (1.5.2)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  hirefire-resource!
+  rack
+  rspec

--- a/README.md
+++ b/README.md
@@ -74,6 +74,35 @@ dj_worker: QUEUES=encode,compress bundle exec rake jobs:work
 
 Now that HireFire will scale both of the these dyno types based on their individual queue sizes. To customize how they scale, log in to the HireFire web interface.
 
+
+## DynoList configuration
+
+If you have a bunch of dynos with the same worker, you can set them up more
+conveniently (and performantly) by configuring the list of dynos with
+your chosen worker library. Currently this is supported by:
+
+* Sidekiq (:sidekiq)
+
+It works like this:
+
+```ruby
+HireFire::Resource.configure do |config|
+  # Tell the HireFire resource you're using the sidekiq shorthand
+  config.dynos = :sidekiq
+
+  # With these calls, we'll only pull the stats from sidekiq once for all
+  # queues, then match them up to the configured dyno names
+  config.dyno(:fast => ['mailers', 'metrics'])
+  config.dyno(:slow => [/generate_.+_report/, 'do_hard_work'])
+
+  # Note you can still configure jobs for other libraries if necessary:
+  config.dyno(:dj_worker) do
+    HireFire::Macro::Delayed::Job.queue(:encode, :compress)
+  end
+end
+```
+
+
 Visit the [official website](http://hirefire.io/) for more information!
 
 ### License

--- a/config.ru
+++ b/config.ru
@@ -1,8 +1,18 @@
 require ::File.expand_path('../lib/hirefire-resource',  __FILE__)
+require 'sidekiq'
 use HireFire::Middleware
 HireFire::Resource.configure do |config|
+  config.dynos = :sidekiq
   config.dyno(:queue1){ rand(100) }
   config.dyno(:queue2){ rand(100) }
+  config.dyno(:sidekiq) do
+    HireFire::Macro::Sidekiq.queue(%w(low_facebook_metrics low_linkedin_metrics))
+  end
+  config.dyno(:facebook => /facebook/)
+  config.dyno(:linkedin, /linkedin/)
+  config.dyno(:social => [/facebook/, /linkedin/])
+  config.dyno(:social_entities => [/facebook_entity/, /linkedin_entity/])
+
 end
 
 run lambda{|env| [200, {}, ["hello world"]] }

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,8 @@
+require ::File.expand_path('../lib/hirefire-resource',  __FILE__)
+use HireFire::Middleware
+HireFire::Resource.configure do |config|
+  config.dyno(:queue1){ rand(100) }
+  config.dyno(:queue2){ rand(100) }
+end
+
+run lambda{|env| [200, {}, ["hello world"]] }

--- a/hirefire-resource.gemspec
+++ b/hirefire-resource.gemspec
@@ -10,6 +10,9 @@ Gem::Specification.new do |gem|
   gem.summary     = "HireFire - The Heroku Dyno Manager"
   gem.description = "HireFire - The Heroku Dyno Manager"
 
+  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rack'
+
   gem.files         = %x[git ls-files].split("\n")
   gem.executables   = ["hirefire", "hirefireapp"]
   gem.require_path  = "lib"

--- a/lib/hirefire-resource.rb
+++ b/lib/hirefire-resource.rb
@@ -2,7 +2,7 @@
 
 HIREFIRE_PATH = File.expand_path("../hirefire", __FILE__)
 
-%w[middleware resource].each do |file|
+%w[middleware resource dyno_list].each do |file|
   require "#{HIREFIRE_PATH}/#{file}"
 end
 

--- a/lib/hirefire-resource.rb
+++ b/lib/hirefire-resource.rb
@@ -2,12 +2,16 @@
 
 HIREFIRE_PATH = File.expand_path("../hirefire", __FILE__)
 
-%w[middleware resource dyno_list].each do |file|
+%w[json_formatter middleware resource dyno_list].each do |file|
   require "#{HIREFIRE_PATH}/#{file}"
 end
 
 %w[delayed_job resque sidekiq qu qc].each do |file|
   require "#{HIREFIRE_PATH}/macro/#{file}"
+end
+
+%w[sidekiq].each do |file|
+  require "#{HIREFIRE_PATH}/dyno_lists/#{file}"
 end
 
 require "#{HIREFIRE_PATH}/railtie" if defined?(Rails::Railtie)

--- a/lib/hirefire/dyno_list.rb
+++ b/lib/hirefire/dyno_list.rb
@@ -1,0 +1,44 @@
+# encoding: utf-8
+
+module HireFire
+  class DynoList
+    # @return [Hash] The configured dynos.
+    attr_accessor :dynos
+
+    def initialize
+      @dynos ||= {}
+    end
+
+    # Used to add a dyno to the list of dynos
+    #
+    # @param [Symbol, String] name the name of the dyno as defined in the Procfile.
+    # @param [Proc] block an Integer containing the quantity calculation logic.
+    #
+    def add(name, &block)
+      @dynos[name] = block
+    end
+
+    # Generates a hash by calling the configured block for each dyno in {#dynos}
+    #
+    # @return [Hash] the return able list of names/quatities
+    #
+    def to_hash
+      @dynos.inject({}) do |hash, (name, block)|
+        hash[name] = block.call
+        hash
+      end
+    end
+
+    # Generates a json string representing the data from calling {#to_hash}
+    #
+    # @return [String] the json representation of data from {#to_hash}
+    #
+    def to_json
+      dyno_data = to_hash.inject(String.new) do |json, (name, quantity)|
+        json << %|,{"name":"#{name}","quantity":#{quantity || "null"}}|; json
+      end
+
+      "[#{dyno_data.sub(",","")}]"
+    end
+  end
+end

--- a/lib/hirefire/dyno_list.rb
+++ b/lib/hirefire/dyno_list.rb
@@ -14,7 +14,7 @@ module HireFire
     # @param [Symbol, String] name the name of the dyno as defined in the Procfile.
     # @param [Proc] block an Integer containing the quantity calculation logic.
     #
-    def add(name, &block)
+    def add(name, *args, &block)
       @dynos[name] = block
     end
 

--- a/lib/hirefire/dyno_list.rb
+++ b/lib/hirefire/dyno_list.rb
@@ -34,11 +34,7 @@ module HireFire
     # @return [String] the json representation of data from {#to_hash}
     #
     def to_json
-      dyno_data = to_hash.inject(String.new) do |json, (name, quantity)|
-        json << %|,{"name":"#{name}","quantity":#{quantity || "null"}}|; json
-      end
-
-      "[#{dyno_data.sub(",","")}]"
+      HireFire::JsonFormatter.to_json(to_hash)
     end
   end
 end

--- a/lib/hirefire/dyno_lists/sidekiq.rb
+++ b/lib/hirefire/dyno_lists/sidekiq.rb
@@ -3,6 +3,32 @@
 module HireFire
   module DynoLists
     class Sidekiq < ::HireFire::DynoList
+
+      # Used to add a dyno to the list of dynos
+      #
+      # You can call this in a few ways:
+      #
+      #   list.add(name: %w(queue1 queue2))
+      #   list.add(:name, %w(queue1 queue2))
+      #   list.add(:name, /^queue[12]$/)
+      #   list.add(:name => [/^queue1$/, /^queue2$/])
+      #   list.add(:name) do
+      #     HireFire::Macro::Sidekiq.queue(%w(queue1 queue2))
+      #   end
+      #
+      # Would all give the same results, though the last one
+      # would require additional calls to sidekiq to generate the
+      # counts. Queues listed as strings or matched by regexes
+      # only require a single call to sidekiq, so generally try
+      # to avoid the block form if possible.
+      #
+      # @param [Symbol, String, Hash] name the name of the dyno as defined in the Procfile. If
+      #   a hash is passed in, the first key is used as the name, and then
+      #   the first value is set as the second argument
+      # @param [Array<String>,Array<Regexp>,Regexp,String] queues list of queue names or regexes to
+      #   match queue names against dynamically
+      # @param [Proc] block an Integer containing the quantity calculation logic.
+      #
       def add(name, *queues, &block)
         return super if block_given?
         if name.is_a?(Hash)
@@ -12,6 +38,12 @@ module HireFire
         dynos[name] = queues.flatten
       end
 
+      # Generates a hash by calling {HireFire::Macro::Sidekiq.queue_list} and
+      # then matching each configured dyno (added with {#add}) against the
+      # list of quantities for queues sidekiq provided stats for.
+      #
+      # @return [Hash] the renderable list of names/quatities
+      #
       def to_hash
         data = HireFire::Macro::Sidekiq.queue_list
         @dynos.inject({}) do |hash, (name, block)|

--- a/lib/hirefire/dyno_lists/sidekiq.rb
+++ b/lib/hirefire/dyno_lists/sidekiq.rb
@@ -1,0 +1,40 @@
+# encoding: utf-8
+
+module HireFire
+  module DynoLists
+    class Sidekiq < ::HireFire::DynoList
+      def add(name, *queues, &block)
+        return super if block_given?
+        if name.is_a?(Hash)
+          queues << name.values.first
+          name = name.keys.first
+        end
+        dynos[name] = queues.flatten
+      end
+
+      def to_hash
+        data = HireFire::Macro::Sidekiq.queue_list
+        @dynos.inject({}) do |hash, (name, block)|
+          if block.is_a?(Array)
+            hash[name] = 0
+            block.each do |queue|
+              case queue
+              when Symbol, String
+                hash[name] += (data[queue.to_s] || 0)
+              when Regexp
+                data.each do |k,v|
+                  hash[name] += v if k =~ queue
+                end
+              else
+                # Should we raise here, or ignore silently?
+              end
+            end
+          else
+            hash[name] = block.call
+          end
+          hash
+        end
+      end
+    end
+  end
+end

--- a/lib/hirefire/json_formatter.rb
+++ b/lib/hirefire/json_formatter.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+module HireFire
+  module JsonFormatter
+    extend self
+
+    # Generates a json string representing the queue_list passed in
+    #
+    # @param [Hash] queue_list list of queue names and quantities.
+    # @return [String] the json representation of data from {#to_hash}
+    #
+    def to_json(queue_list)
+      dyno_data = queue_list.inject(String.new) do |json, (name, quantity)|
+        json << %|,{"name":"#{name}","quantity":#{quantity || "null"}}|; json
+      end
+
+      "[#{dyno_data.sub(",","")}]"
+    end
+  end
+end

--- a/lib/hirefire/macro/sidekiq.rb
+++ b/lib/hirefire/macro/sidekiq.rb
@@ -43,7 +43,10 @@ module HireFire
 
         ::Sidekiq::Workers.new.each do |job|
           job_info = job[1]
-          all_queues[job_info["queue"].to_s] += 1 if job_info["run_at"] <= Time.now.to_i
+          # As long as this is still a valid job
+          if job_info && job_info["run_at"]
+            all_queues[job_info["queue"].to_s] += 1 if job_info["run_at"] <= Time.now.to_i
+          end
         end
         all_queues
       end

--- a/lib/hirefire/middleware.rb
+++ b/lib/hirefire/middleware.rb
@@ -7,8 +7,11 @@ module HireFire
     # and `ENV["HIREFIRE_TOKEN"]` in `@token` for convenience.
     #
     # @param [ActionDispatch::Routing::RouteSet] app.
+    # @param [HireFire::JsonFormatter,#to_json] formatter anything that can turn format a hash
+    #   into expected HireFire json format
     #
-    def initialize(app)
+    def initialize(app, formatter = HireFire::JsonFormatter)
+      @formatter = formatter
       @app   = app
       @token = ENV["HIREFIRE_TOKEN"]
     end
@@ -53,7 +56,7 @@ module HireFire
     # @return [String] in JSON format.
     #
     def dynos
-      HireFire::Resource.dynos.to_json
+      @formatter.to_json(HireFire::Resource.dynos.to_hash)
     end
 
     # Returns true if the PATH_INFO matches the test url.

--- a/lib/hirefire/middleware.rb
+++ b/lib/hirefire/middleware.rb
@@ -48,16 +48,12 @@ module HireFire
 
     private
 
-    # Generates a JSON string based on the dyno data.
+    # Generates a JSON string by calling dynos.to_json
     #
     # @return [String] in JSON format.
     #
     def dynos
-      dyno_data = HireFire::Resource.dynos.inject(String.new) do |json, dyno|
-        json << %|,{"name":"#{dyno[:name]}","quantity":#{dyno[:quantity].call || "null"}}|; json
-      end
-
-      "[#{dyno_data.sub(",","")}]"
+      HireFire::Resource.dynos.to_json
     end
 
     # Returns true if the PATH_INFO matches the test url.

--- a/lib/hirefire/resource.rb
+++ b/lib/hirefire/resource.rb
@@ -27,13 +27,25 @@ module HireFire
       @dynos ||= DynoList.new
     end
 
+    # @param [HireFire::DynoList,Object] dyno_list the DynoList class or an instance of it. You can
+    #   use anything instance that responds to {#to_hash}
+    def dynos=(dyno_list)
+      dyno_list = dyno_list.new if dyno_list.is_a?(Class)
+      if dyno_list.respond_to?(:to_hash)
+        @dynos = dyno_list
+      else
+        raise ArgumentError.new('Must be a class/instance of HireFire::DynoList or another class that responds to #to_hash')
+      end
+    end
+
     # Will be used through block-style configuration with the `configure` method.
     #
     # @param [Symbol, String] name the name of the dyno as defined in the Procfile.
+    # @param [Array] args additional args, potentially used by the current dyno list
     # @param [Proc] block an Integer containing the quantity calculation logic.
     #
-    def dyno(name, &block)
-      dynos.add(name, &block)
+    def dyno(name, *args, &block)
+      dynos.add(name, *args, &block)
     end
   end
 end

--- a/lib/hirefire/resource.rb
+++ b/lib/hirefire/resource.rb
@@ -4,9 +4,6 @@ module HireFire
   module Resource
     extend self
 
-    # @return [Array] The configured dynos.
-    #
-    attr_accessor :dynos
 
     # Sets the `@dynos` instance variable to an empty Array to hold all the dyno configuration.
     #
@@ -20,8 +17,14 @@ module HireFire
     # @yield [HireFire::Resource] to allow for block-style configuration.
     #
     def configure
-      @dynos ||= []
+      @dynos ||= DynoList.new
       yield self
+    end
+
+    # @return [HireFire::DynoList] The configured dyno list
+    #
+    def dynos
+      @dynos ||= DynoList.new
     end
 
     # Will be used through block-style configuration with the `configure` method.
@@ -30,7 +33,7 @@ module HireFire
     # @param [Proc] block an Integer containing the quantity calculation logic.
     #
     def dyno(name, &block)
-      @dynos << { :name => name, :quantity => block }
+      dynos.add(name, &block)
     end
   end
 end

--- a/spec/dyno_list_spec.rb
+++ b/spec/dyno_list_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe HireFire::DynoList do
+  it 'can add dynos and generate a hash' do
+    dynamic = 0
+    subject.add(:queue1){ 1 }
+    subject.add(:queue2){ 2 }
+    subject.add(:queue3){ dynamic += 1 }
+    subject.to_hash[:queue1].should == 1
+    subject.to_hash[:queue2].should == 2
+    subject.to_hash[:queue3].should == 3
+  end
+  it 'can generate json from to_hash' do
+    subject.add(:queue1){ 1 }
+    subject.add(:queue2){ 2 }
+    subject.add(:queue3){  }
+    subject.should_receive(:to_hash).and_call_original
+    json = subject.to_json
+    json.should match(/{"name":"queue2","quantity":1}/)
+    json.should match(/{"name":"queue3","quantity":null}/)
+    json.should match(/^\[.+\]$/)
+  end
+end
+

--- a/spec/dyno_list_spec.rb
+++ b/spec/dyno_list_spec.rb
@@ -16,7 +16,7 @@ describe HireFire::DynoList do
     subject.add(:queue3){  }
     subject.should_receive(:to_hash).and_call_original
     json = subject.to_json
-    json.should match(/{"name":"queue2","quantity":1}/)
+    json.should match(/{"name":"queue1","quantity":1}/)
     json.should match(/{"name":"queue3","quantity":null}/)
     json.should match(/^\[.+\]$/)
   end

--- a/spec/dyno_lists/sidekiq_spec.rb
+++ b/spec/dyno_lists/sidekiq_spec.rb
@@ -6,7 +6,7 @@ describe HireFire::DynoLists::Sidekiq do
       'a' => 1,
       'c' => 3,
       'd' => 4,
-      'e' => 0,
+      'e' => 2,
       'd.1' => 5,
       'd.2' => 6,
       'f' => 7
@@ -14,14 +14,14 @@ describe HireFire::DynoLists::Sidekiq do
   }
   it 'can add dynos and generate a hash' do
     subject.add(:queue1, %w[a b c])
-    subject.add(:queue2 => [/d/, "e", /g/])
+    subject.add(:queue2 => [/d/, :e, /g/])
     subject.add(:queue3 => /f/)
     subject.add(:queue4) do
       4
     end
     HireFire::Macro::Sidekiq.should_receive(:queue_list).exactly(4).times.and_return(queues)
     subject.to_hash[:queue1].should == 4
-    subject.to_hash[:queue2].should == 15
+    subject.to_hash[:queue2].should == 17
     subject.to_hash[:queue3].should == 7
     subject.to_hash[:queue4].should == 4
   end

--- a/spec/dyno_lists/sidekiq_spec.rb
+++ b/spec/dyno_lists/sidekiq_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe HireFire::DynoLists::Sidekiq do
+  let(:queues){
+    {
+      'a' => 1,
+      'c' => 3,
+      'd' => 4,
+      'e' => 0,
+      'd.1' => 5,
+      'd.2' => 6,
+      'f' => 7
+    }
+  }
+  it 'can add dynos and generate a hash' do
+    subject.add(:queue1, %w[a b c])
+    subject.add(:queue2 => [/d/, "e", /g/])
+    subject.add(:queue3 => /f/)
+    subject.add(:queue4) do
+      4
+    end
+    HireFire::Macro::Sidekiq.should_receive(:queue_list).exactly(4).times.and_return(queues)
+    subject.to_hash[:queue1].should == 4
+    subject.to_hash[:queue2].should == 15
+    subject.to_hash[:queue3].should == 7
+    subject.to_hash[:queue4].should == 4
+  end
+end

--- a/spec/json_formatter_spec.rb
+++ b/spec/json_formatter_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe HireFire::JsonFormatter do
+  it 'can generate json from to_hash' do
+    hash = {
+      :queue1 => 1,
+      :queue2 => 2,
+      :queue3 => nil,
+    }
+    json = subject.to_json(hash)
+    json.should match(/{"name":"queue1","quantity":1}/)
+    json.should match(/{"name":"queue3","quantity":null}/)
+    json.should match(/^\[.+\]$/)
+  end
+end
+

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe HireFire::Resource do
+  it 'has a default dyno list' do
+    described_class.dynos.should be_a(HireFire::DynoList)
+  end
+  it 'can add dyno list by symbolized type' do
+    described_class.dynos = :sidekiq
+    described_class.dynos.should be_a(HireFire::DynoLists::Sidekiq)
+  end
+  it 'can add a dyno list by class' do
+    described_class.dynos = HireFire::DynoLists::Sidekiq
+    described_class.dynos.should be_a(HireFire::DynoLists::Sidekiq)
+  end
+  it 'verifies responding to #to_hash' do
+    expect {
+      described_class.dynos = Array.new
+    }.to raise_error(ArgumentError, /to_hash/)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'hirefire-resource'


### PR DESCRIPTION
Set of changes to allow configuring a longer list of dynos more easily and computing them more efficiently than running the macro once per dyno. Currently only supports sidekiq. It looks something like this:

``` ruby
HireFire::Resource.configure do |config|
  # Tell the HireFire resource you're using the sidekiq dyno list
  config.dynos = :sidekiq

  # With these calls, we'll only pull the stats from sidekiq once for all
  # queues, then match them up to the configured dyno names
  config.dyno(:fast, %w(mailers metrics))
  config.dyno(:slow => [/generate_.+_report/, 'do_hard_work'])

  # Note you can still configure jobs for other libraries if necessary:
  config.dyno(:dj_worker) do
    HireFire::Macro::Delayed::Job.queue(:encode, :compress)
  end
end
```
