### PR TITLE
add RabbitMQ support using Bunny

### DIFF
--- a/lib/hirefire-resource.rb
+++ b/lib/hirefire-resource.rb
@@ -6,7 +6,7 @@ HIREFIRE_PATH = File.expand_path("../hirefire", __FILE__)
   require "#{HIREFIRE_PATH}/#{file}"
 end
 
-%w[delayed_job resque sidekiq qu qc].each do |file|
+%w[delayed_job resque sidekiq qu qc bunny].each do |file|
   require "#{HIREFIRE_PATH}/macro/#{file}"
 end
 

--- a/lib/hirefire/macro/bunny.rb
+++ b/lib/hirefire/macro/bunny.rb
@@ -1,0 +1,80 @@
+# encoding: utf-8
+
+module HireFire
+  module Macro
+    module Bunny
+      extend self
+
+      # Returns the job quantity for the provided queue(s).
+      #
+      # @example Bunny Macro Usage
+      #
+      #   # all queues using existing RabbitMQ connection.
+      #   HireFire::Macro::Bunny.queue("queue1", "queue2", :connection => connection)
+      #
+      #   # all queues using new RabbitMQ connection.
+      #   HireFire::Macro::Bunny.queue("queue1", "queue2", :amqp_url => url)
+      #
+      #   # all non-durable queues using new RabbitMQ connection.
+      #   HireFire::Macro::Bunny.queue("queue1", "queue2", :amqp_url => url, :durable => false)
+      #
+      # @param [Array] queues provide one or more queue names, or none for "all".
+      #   Last argument can pass in a Hash containing :connection => rabbitmq_connection or :amqp => :rabbitmq_url
+      # @return [Integer] the number of jobs in the queue(s).
+      #
+      def queue(*queues)
+        require "bunny"
+
+        queues.flatten!
+
+        if queues.last.is_a?(Hash)
+          options = queues.pop
+        else
+          options = {}
+        end
+
+        if options[:durable].nil?
+          options[:durable] = true
+        end
+
+        if options[:connection]
+          connection = options[:connection]
+
+          channel = nil
+          begin
+            channel = connection.create_channel
+            return count_messages(channel, queues, options)
+          ensure
+            if channel
+              channel.close
+            end
+          end
+        elsif options[:amqp_url]
+          connection = ::Bunny.new(options[:amqp_url])
+          begin
+            connection.start
+            channel = connection.create_channel
+            return count_messages(channel, queues, options)
+          ensure
+            if channel
+              channel.close
+            end
+
+            connection.close
+          end
+        else
+          raise %{Must pass in :connection => rabbitmq_connection or :amqp_url => url\n} +
+                  %{For example: HireFire::Macro::Bunny.queue("queue1", :connection => rabbitmq_connection}
+        end
+      end
+
+      def count_messages(channel, queue_names, options)
+        queue_names.inject(0) do |sum, queue_name|
+          queue = channel.queue(queue_name, :durable => options[:durable])
+          sum + queue.message_count
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Allow HireFire to look at number of messages in RabbitMQ queues. Sample setup:
```
    # using connection URL
    config.dyno(:worker) do
      HireFire::Macro::Bunny.queue("results", amqp_url: ENV["CLOUDAMQP_URL"])
    end

    # using Bunny connection
    config.dyno(:worker) do
      HireFire::Macro::Bunny.queue("results", connection: $rabbitmq_connection)
    end

    # non durable queues
    config.dyno(:worker) do
      HireFire::Macro::Bunny.queue("results", connection: $rabbitmq_connection, durable: false)
    end
```

I tested this in my app with HireFire and it works without problems. 