### PR TITLE
Basic handling for SQS queues

### DIFF
--- a/lib/hirefire-resource.rb
+++ b/lib/hirefire-resource.rb
@@ -6,7 +6,7 @@ HIREFIRE_PATH = File.expand_path("../hirefire", __FILE__)
   require "#{HIREFIRE_PATH}/#{file}"
 end
 
-%w[delayed_job resque sidekiq qu qc bunny].each do |file|
+%w[delayed_job resque sidekiq qu qc bunny sqs].each do |file|
   require "#{HIREFIRE_PATH}/macro/#{file}"
 end
 

--- a/lib/hirefire/macro/sqs.rb
+++ b/lib/hirefire/macro/sqs.rb
@@ -18,7 +18,7 @@ module HireFire
       def queue(*queues)
         queues = queues.flatten.map(&:to_s)
         length = 0
-        client = Aws::SQS::Client.net
+        client = Aws::SQS::Client.new
         queue_urls = client.list_queues.queue_urls
         sample_url = queue_urls.first
         suffix = sample_url.split('/').last

--- a/lib/hirefire/macro/sqs.rb
+++ b/lib/hirefire/macro/sqs.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+
+module HireFire
+  module Macro
+    module Sqs
+      extend self
+
+      # Counts the approximate number of jobs in the provided SQS queue.
+      #
+      # @example SQS Macro Usage
+      #   HireFire::Macro::Sqs.queue # all queues
+      #   HireFire::Macro::Sqs.queue("email") # only email queue
+      #   HireFire::Macro::Sqs.queue("audio", "video") # audio and video queues
+      #
+      # @param [Array] queues provide one or more queue names, or none for "all".
+      # @return [Integer] the number of jobs in the queue(s).
+      #
+      def queue(*queues)
+        length = 0
+        client = Aws::SQS::Client.net
+        queue_urls = client.list_queues.queue_urls
+        sample_url = queue_urls.first
+        suffix = sample_url.split('/').last
+        sample_url.slice!(suffix)
+        prefix = sample_url
+        queues.each do |queue_name|
+          queue_url = prefix + queue_name
+          attributes = client.get_queue_attributes({queue_url: queue_url, 
+                                                    attribute_names: ["ApproximateNumberOfMessages"]}).attributes
+          num_messages = attributes["ApproximateNumberOfMessages"].to_i
+          length += num_messages
+        end
+        length
+      end
+    end
+  end
+end

--- a/lib/hirefire/macro/sqs.rb
+++ b/lib/hirefire/macro/sqs.rb
@@ -16,6 +16,7 @@ module HireFire
       # @return [Integer] the number of jobs in the queue(s).
       #
       def queue(*queues)
+        queues = queues.flatten.map(&:to_s)
         length = 0
         client = Aws::SQS::Client.net
         queue_urls = client.list_queues.queue_urls


### PR DESCRIPTION
Had a scenario where I instantiate workers that process an SQS queue and needed to have monitoring be based off of SQS queue message length. This only requires the queue name rather than the full URL and has been tested and is working in production for us.