### PR TITLE
Fix Rails 5 deprecation warning

### DIFF
--- a/lib/hirefire/railtie.rb
+++ b/lib/hirefire/railtie.rb
@@ -3,7 +3,7 @@
 module HireFire
   class Railtie < ::Rails::Railtie
     initializer "hirefire.add_middleware" do |app|
-      app.config.middleware.insert 0, "HireFire::Middleware"
+      app.config.middleware.insert 0, HireFire::Middleware
     end
   end
 end


### PR DESCRIPTION
Getting a deprecation warning when running HireFire with Rails 5.

There might be more things to do for full Rails 5 compatibility (I haven't tried it in production yet) but this at least fixes the deprecation warning.

```
DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references.  For example:

  "HireFire::Middleware" => HireFire::Middleware

 (called from <top (required)> at /Users/philtr/src/.../config/environment.rb:5)
```