### PR TITLE
use class name to avoid deprecation warning

### DIFF
--- a/lib/hirefire/railtie.rb
+++ b/lib/hirefire/railtie.rb
@@ -3,7 +3,7 @@
 module HireFire
   class Railtie < ::Rails::Railtie
     initializer "hirefire.add_middleware" do |app|
-      app.config.middleware.insert 0, "HireFire::Middleware"
+      app.config.middleware.insert 0, HireFire::Middleware
     end
   end
 end


### PR DESCRIPTION
Using a string to reference `HireFire::Middleware` causes the following deprecation warning:

```text
DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references.  For example:

  "HireFire::Middleware" => HireFire::Middleware
```

Referencing the `HireFire::Middleware` class directly removes the warning.