### PR TITLE
Remove dependency on que-web

### DIFF
--- a/lib/hirefire/macro/que.rb
+++ b/lib/hirefire/macro/que.rb
@@ -3,6 +3,16 @@
 module HireFire
   module Macro
     module Que
+      QUERY =  %{
+SELECT count(*)                                                          AS total,
+       count(locks.job_id)                                               AS running,
+       coalesce(sum((error_count > 0 AND locks.job_id IS NULL)::int), 0) AS failing,
+       coalesce(sum((error_count = 0 AND locks.job_id IS NULL)::int), 0) AS scheduled
+FROM que_jobs LEFT JOIN (
+  SELECT (classid::bigint << 32) + objid::bigint AS job_id
+  FROM pg_locks WHERE locktype = 'advisory'
+) locks USING (job_id) }.freeze
+
       extend self
 
       # Queries the PostgreSQL database through Que in order to
@@ -16,8 +26,7 @@ module HireFire
       # @return [Integer] the number of jobs in the queue(s).
       #
       def queue(queue = nil)
-        query = ::Que::Web::SQL[:dashboard_stats]
-        query = "#{query} WHERE queue = '#{queue}'" if queue
+        query = queue ? "#{QUERY} WHERE queue = '#{queue}'" : QUERY
         results = ::Que.execute(query).first
         results["total"].to_i - results["failing"].to_i
       end


### PR DESCRIPTION
Instead of using que-web's query, which can change and requires that
que-web is installed, inline the query we use to get the count of
pending jobs.

@mrrooijen just got bit by this with an upgrade to que-web where the query was changed. To me we should not require que-web for this gem.