### PR TITLE
Faster Sidekiq counts ⚡

### DIFF
--- a/lib/hirefire/macro/sidekiq.rb
+++ b/lib/hirefire/macro/sidekiq.rb
@@ -28,9 +28,44 @@ module HireFire
           options = {}
         end
 
-        queues = queues.map(&:to_s)
-        queues = ::Sidekiq::Stats.new.queues.map { |name, _| name } if queues.empty?
+        queues.map!(&:to_s)
+        all_queues = ::Sidekiq::Queue.all.map(&:name)
+        queues = all_queues if queues.empty?
 
+        if fast_lookup_capable?(queues, all_queues)
+          fast_lookup(options)
+        else
+          dynamic_lookup(queues, options)
+        end
+      end
+
+      private
+
+      def fast_lookup_capable?(queues, all_queues)
+        # When no queue names are provided (or all of them are), we know we
+        # can peform much faster counts using Sidekiq::Stats and Redis
+        queues.sort == all_queues.sort
+      end
+
+      def fast_lookup(options)
+        stats = ::Sidekiq::Stats.new
+
+        in_queues = stats.enqueued
+
+        if !options[:skip_scheduled]
+          in_schedule = ::Sidekiq.redis { |c| c.zcount('schedule', '-inf', Time.now.to_f) }
+        end
+
+        if !options[:skip_retries]
+          in_retry = ::Sidekiq.redis { |c| c.zcount('retry', '-inf', Time.now.to_f) }
+        end
+
+        in_progress = stats.workers_size
+
+        [in_queues, in_schedule, in_retry, in_progress].compact.inject(&:+)
+      end
+
+      def dynamic_lookup(queues, options)
         in_queues = queues.inject(0) do |memo, name|
           memo += ::Sidekiq::Queue.new(name).size
           memo
@@ -38,25 +73,34 @@ module HireFire
 
         if !options[:skip_scheduled]
           max = options[:max_scheduled]
+
+          # For potentially long-running loops, compare all jobs against
+          # time when the set snapshot was taken to avoid incorrect counts.
+          now = Time.now
+
           in_schedule = ::Sidekiq::ScheduledSet.new.inject(0) do |memo, job|
-            memo += 1 if queues.include?(job["queue"]) && job.at <= Time.now
+            memo += 1 if queues.include?(job["queue"]) && job.at <= now
             break memo if max && memo >= max
             memo
           end
         end
 
         if !options[:skip_retries]
+          now = Time.now
+
           in_retry = ::Sidekiq::RetrySet.new.inject(0) do |memo, job|
-            memo += 1 if queues.include?(job["queue"]) && job.at <= Time.now
+            memo += 1 if queues.include?(job["queue"]) && job.at <= now
             memo
           end
         end
 
-        i = ::Sidekiq::VERSION >= "3.0.0" ? 2 : 1
-        in_progress = ::Sidekiq::Workers.new.inject(0) do |memo, job|
-          memo += 1 if queues.include?(job[i]["queue"]) && job[i]["run_at"] <= Time.now.to_i
-          memo
-        end
+        now = Time.now.to_i
+
+        # Objects yielded to Workers#each:
+        # https://github.com/mperham/sidekiq/blob/305ab8eedc362325da2e218b2a0e20e510668a42/lib/sidekiq/api.rb#L912
+        in_progress = ::Sidekiq::Workers.new.select do |key, tid, job|
+          queues.include?(job['queue']) && job['run_at'] <= now
+        end.size
 
         [in_queues, in_schedule, in_retry, in_progress].compact.inject(&:+)
       end


### PR DESCRIPTION
Areas I'm addressing in this PR:

1. Making Sidekiq counts fast out of the box⚡
2. Fixing workers count

#### Faster Sidekiq counts
This update should make Hirefire Sidekiq counts super fast for users with zero additional config (simply calling `HireFire::Macro::Sidekiq.queue` with no arguments, like we do).

Currently, when scheduled counts are included and even with `max_scheduled` specified (5,000 in our case), the count takes a very long time when many jobs are present, e.g. my scenario:

![screen shot 2018-08-28 at 2 23 24 pm](https://user-images.githubusercontent.com/7811733/44707809-bb2c6080-aacf-11e8-92fc-99c311b288ac.png)

Using a simple benchmark:

```ruby
def benchmark
  t1 = Time.now
  yield
  t2 = Time.now
  p "Time taken: #{((t2 - t1) * 1000.0).to_i} ms"
end

# Current
benchmark do
  val = Sidekiq::ScheduledSet.new.inject(0) do |memo, job|
    memo += 1 if job.at <= Time.now
    memo
  end
  p "#{val} matching jobs."
end

# Updated
benchmark do
  val = Sidekiq.redis { |c| c.zcount('schedule', '-inf', Time.now.to_f) }
  p "#{val} matching jobs."
end
```

I verified the difference is massive: current 45419 ms vs 2 ms when the count is offloaded to Redis. This is the approach [used internally](https://github.com/mperham/sidekiq/blob/e4b7b911f60d22c2ff96ed5443b525ab1f47441c/lib/sidekiq/scheduled.rb#L20) by Sidekiq. Equally fast approach can be used for all other counts.

One more issue I uncovered here is that the current approach results in a wrong (higher) count simply because the loop takes so long.

#### Workers count
I'm using Sidekiq `4.1.1` where the objects yielded to `Workers` instance are as follows:

```ruby
"sidekiq.4:3:441559cd6484"
"ou0w76y5w"
{"queue"=>"integration", "payload"=>{"class"=>"Integrations::GenericWorker", "args"=>["Integrations::Apis::LinkedInLearning", "8bee650e-25fb-4829-a733-a3aab353ab5e"], "retry"=>true, "queue"=>"integration", "jid"=>"5d53fd6dc7d33994f27f6b25", "created_at"=>1535439610.2583237, "enqueued_at"=>1535439610.2583618}, "run_at"=>1535439620}
"sidekiq.4:3:441559cd6484"
```

given that, `queues.include?(job[i]["queue"])` in the original implementation simply returned `nil` so 
`job[i]["run_at"] <= Time.now.to_i` was never evaluated (otherwise would throw an error - `undefined method '<=' for nil:NilClass`). 

We'll need to verify for other versions of Sidekiq, I only tested on `4.1.1`.

@mrrooijen this a first draft. I wanted to hear your feedback first before we can polish this up. No spec coverage makes me a little bit uneasy, I could look into setting up a basic suite covering this if you see value in it.
