### PR TITLE
Fix Hirefire middleware not threadsafe

### DIFF
--- a/lib/hirefire/middleware.rb
+++ b/lib/hirefire/middleware.rb
@@ -25,12 +25,17 @@ module HireFire
       end
     end
 
+    # We must duplicate the call the ensure thread safety when working in mult-threaded env
+    def call(env)
+      dup._call(env)
+    end
+
     # Will respond to the request here if either the `test` or the `info` url was requested.
     # Otherwise, fall through to the rest of the middleware below HireFire::Middleware.
     #
     # @param [Hash] env containing request information.
     #
-    def call(env)
+    def _call(env)
       @env = env
 
       handle_queue(env["HTTP_X_REQUEST_START"])


### PR DESCRIPTION
## Problem
We've noticed a bug that some requests at Opendoor were randomly receiving Hirefire's `/hirefire/TOKEN/info` data back to the client instead of their own data. It has been narrowed down to the middleware in Hirefire which does not handle threadsafety. This only happens in rare occasions during the race condition where the Puma server receives a request to `/hirefire/TOKEN/info` and another request at the same time.

## More details 
See https://stackoverflow.com/questions/23028226/rack-middleware-and-thread-safety and https://ieftimov.com/writing-rails-middleware for the background.




