### PR TITLE
Add priority queue support for bunny message count

### DIFF
--- a/lib/hirefire/macro/bunny.rb
+++ b/lib/hirefire/macro/bunny.rb
@@ -70,7 +70,15 @@ module HireFire
 
       def count_messages(channel, queue_names, options)
         queue_names.inject(0) do |sum, queue_name|
-          queue = channel.queue(queue_name, :durable => options[:durable])
+          if options.key?('x-max-priority')
+            queue = channel.queue(queue_name,
+                                  :durable => options[:durable],
+                                  arguments: {
+                                    'x-max-priority': options['x-max-priority']
+                                  } )
+          else
+            queue = channel.queue(queue_name, :durable => options[:durable])
+          end
           sum + queue.message_count
         end
       end


### PR DESCRIPTION
When we attempt to check the amount of messages in a priority queue we get the error: `<Bunny::ChannelAlreadyClosed: cannot use a closed channel! Channel id: 1, closed due to a server-reported channel error: PRECONDITION_FAILED - inequivalent arg 'x-max-priority' for queue 'api:properties' in vhost 'ehcnvgrr': received none but current is the value '10' of type 'signedint'>`

This will allow us to pass in the `x-max-priority` option when opening up a queue to check the messages remaining. Usage: `HireFire::Macro::Bunny.queue(queue, amqp_url: url, 'x-max-priority': 10 )`