### PR TITLE
Use symbol to stay consistent with other options

### DIFF
--- a/lib/hirefire/macro/bunny.rb
+++ b/lib/hirefire/macro/bunny.rb
@@ -70,9 +70,9 @@ module HireFire
 
       def count_messages(channel, queue_names, options)
         queue_names.inject(0) do |sum, queue_name|
-          if options.key?("x-max-priority")
+          if options.key?(:'x-max-priority')
             queue = channel.queue(queue_name, :durable   => options[:durable],
-                                              :arguments => {"x-max-priority" => options["x-max-priority"]})
+                                              :arguments => {"x-max-priority" => options[:'x-max-priority']})
           else
             queue = channel.queue(queue_name, :durable => options[:durable])
           end


### PR DESCRIPTION
The other options in here are all symbols and the `x-max-priority` option was used as a string. It makes sense to use a symbol here as well to be consistent. New usage:
`HireFire::Macro::Bunny.queue(queue, amqp_url: url, 'x-max-priority': 10 )`