### PR TITLE
Add gem metadata to gemspec

### DIFF
--- a/hirefire-resource.gemspec
+++ b/hirefire-resource.gemspec
@@ -10,6 +10,12 @@ Gem::Specification.new do |gem|
   gem.summary = "Autoscaling for your Heroku dynos"
   gem.description = "Load- and schedule-based scaling for web- and worker dynos"
   gem.licenses = ["Apache License"]
+  gem.metadata = {
+    "homepage_uri" => "https://www.hirefire.io",
+    "changelog_uri" => "https://github.com/hirefire/hirefire-resource/blob/master/CHANGELOG.md",
+    "source_code_uri" => "https://github.com/hirefire/hirefire-resource/",
+    "bug_tracker_uri" => "https://github.com/hirefire/hirefire-resource/issues",
+  }
 
   gem.files = %x[git ls-files].split("\n")
   gem.executables = ["hirefire", "hirefireapp"]


### PR DESCRIPTION
This should allow services like Dependabot to provide links to the changelog when automated dependency upgrade PRs are created.