### PR TITLE
Correct good job macro to not count finished jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## v0.8.0/Master
+## Master
+
+* Correct GoodJob macro to not count finished jobs.
+
+## v0.8.0
 
 * Add GoodJob macro for `good_job` adapter. https://github.com/bensheldon/good_job
 

--- a/lib/hirefire/macro/good_job.rb
+++ b/lib/hirefire/macro/good_job.rb
@@ -16,7 +16,7 @@ module HireFire
       # @return [Integer] the number of jobs in the queue(s).
       #
       def queue(*queues)
-        scope = ::GoodJob::Job.only_scheduled
+        scope = ::GoodJob::Job.only_scheduled.unfinished
         scope = scope.where(queue_name: queues) if queues.any?
         scope.count
       end


### PR DESCRIPTION
It is possible to configure GoodJob to preserve finished jobs in database vide https://github.com/bensheldon/good_job#global-options